### PR TITLE
Added price per pound detection and dollar sign formatting for Kroger stores.

### DIFF
--- a/src/WebScraping/GroceryStores/FredMeyerScraper.ts
+++ b/src/WebScraping/GroceryStores/FredMeyerScraper.ts
@@ -132,12 +132,26 @@ class FredMeyerScraper {
                 ".kds-Link > .h-full > .kds-Image-img"
             );
 
-            // Extract the current product price using the current product cell and the class structure
-            // The class structure here is just class=kds-Price--alternate this is only used for the product price.
-            const productPrice = await extractorObj.extractFromValue(
+            // With Fred Meyer we want to extract the price per pound for an item if it exists. We first attempt to collect that.
+            // The price per pound for Kroger always follows the below pattern
+            const pricePerPoundRegex = /^\$[\d.]+\/lb$/;
+            // Attempt to extract the price per pound value and store it to productPrice
+            let productPrice;
+            productPrice = await extractorObj.extractTextContent(
                 product,
-                ".kds-Price--alternate"
+                "div > * >.kds-Text--s"
             );
+            // If the product price does not match the pattern then the span that displays price per pound does not exist and we need to collect
+            // the default price tag.
+            if(!pricePerPoundRegex.test(productPrice)){
+                // Extract the current product price using the current product cell and the class structure
+                // The class structure here is just class=kds-Price--alternate this is only used for the product price.
+                const priceValue = await extractorObj.extractFromValue(
+                    product,
+                    ".kds-Price--alternate"
+                );
+                productPrice = "$" + priceValue;
+            }
 
             // Extract the current product URL using the current product and targeting the same as product name
             // Kroger shortens the URL to just be p/product-id so we need to add the base url for the site.


### PR DESCRIPTION
### Price Per Pound
For the Kroger stores price per pound was located in a separate span that is also reused shared with the "SNAP EBT" icon.  Added detection for this, the scraper will first try to locate the price per pound span.  If the value the extractor grabbed does not match the $X.XX/lb pattern then we target the main price tag element.

### Dollar sign formatting
Price per pound includes a dollar sign in the string, the main price tag does not.  As Whole Foods includes this in all their prices, we add a dollar sign to improve formatting on the frontend. 