### PR TITLE
Only run prettier and unit test on pull_request 

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,9 +1,7 @@
 name: Prettier
 on:
-  push:
-        branches: [main, master]
-    pull_request:
-        branches: [main, master]
+  pull_request:
+    branches: [main, master]
 permissions: write-all
 jobs:
   prettier:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,7 +1,5 @@
 name: UnitTesting
 on:
-    push:
-        branches: [main, master]
     pull_request:
         branches: [main, master]
 permissions: write-all


### PR DESCRIPTION
Here we are changing the run conditions of Unit Testing and Prettier actions.  As the Unit Test action must pass before deployment being committed into Main, we can safely remove the push trigger.